### PR TITLE
feat: Add Docker-based build for Windows installer

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,0 +1,31 @@
+# Use the Windows Server Core 2022 image as the base.
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+
+# Set up the working directory.
+WORKDIR /build
+
+# Install Chocolatey, a package manager for Windows.
+RUN powershell -NoProfile -ExecutionPolicy Bypass -Command "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
+
+# Use Chocolatey to install Node.js LTS, Git, and Zip.
+# Git is required for some npm packages.
+# Zip is required for the final packaging step.
+RUN choco install nodejs-lts -y --version=18.17.0
+RUN choco install git -y
+RUN choco install zip -y
+
+# Copy the package.json and package-lock.json (if it exists) first to leverage Docker layer caching.
+COPY package.json .
+COPY package-lock.json* .
+
+# Install dependencies.
+RUN npm install
+
+# Copy the rest of the application source code.
+COPY . .
+
+# This is a critical step to apply custom patches.
+RUN npm run monkeypatch
+
+# Set the command to open a PowerShell terminal. This allows for interactive debugging.
+CMD ["powershell"]

--- a/build-windows.sh
+++ b/build-windows.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# A script to build the Windows installer using a Docker container.
+
+set -e
+
+IMAGE_NAME="speedyhawke-ui-windows-builder"
+CONTAINER_NAME="speedyhawke-ui-windows-builder-container"
+
+echo "Building the Windows builder Docker image..."
+docker build -t $IMAGE_NAME -f Dockerfile.windows .
+
+echo "Image built successfully. Creating container..."
+
+# Run the container in the background
+docker run -d --name $CONTAINER_NAME $IMAGE_NAME
+
+echo "Container created. Running the electron-builder..."
+
+# Run the build command inside the container
+docker exec $CONTAINER_NAME powershell -Command "npm run-script mw"
+
+echo "Build complete. Copying the installer from the container..."
+
+# Create a local dist directory if it doesn't exist
+mkdir -p dist
+
+# Copy the installer from the container to the local dist directory
+docker cp $CONTAINER_NAME:/build/dist-win32/SpeedyHawke-UI.exe ./dist/SpeedyHawke-UI-installer.exe
+
+echo "Installer copied to ./dist/SpeedyHawke-UI-installer.exe"
+
+echo "Stopping and removing the container..."
+docker stop $CONTAINER_NAME
+docker rm $CONTAINER_NAME
+
+echo "Done."

--- a/script/zip.js
+++ b/script/zip.js
@@ -4,8 +4,8 @@ const fs = require('fs')
 const version = process.env.npm_package_version
 
 // Windows
-let exePath = path.resolve(__dirname, `../dist/Pinokio Setup ${version}.exe`)
-let zipPath = path.resolve(__dirname, `../dist/Pinokio-${version}-win32.zip`)
+let exePath = path.resolve(__dirname, `../dist-win32/SpeedyHawke-UI.exe`)
+let zipPath = path.resolve(__dirname, `../dist-win32/SpeedyHawke-UI-win32-${version}.zip`)
 exec(`zip -j "${zipPath}" "${exePath}"`, (error, stdout, stderr) => {
   if (error) {
     console.error(`Error executing command: ${error}`);


### PR DESCRIPTION
This change introduces a new build process for creating the Windows installer using a Docker container. This allows for a consistent and repeatable build environment that can be run from any machine with Docker, including from Git Bash on Windows.

- Adds a `Dockerfile.windows` that defines a Windows Server Core environment with Node.js, Git, and the `zip` utility.
- Adds a `build-windows.sh` script to automate the entire build process, from building the Docker image to extracting the final installer.
- Fixes a bug in `script/zip.js` where the script was looking for an incorrect filename and directory, which would have caused the build to fail. The script now correctly finds the `SpeedyHawke-UI.exe` installer in the `dist-win32` directory.
- Updates `Dockerfile.windows` to install the `zip` utility, which is a dependency for the build.